### PR TITLE
assignments:load returns type Response

### DIFF
--- a/admiral-edu/dispatch-typed.rkt
+++ b/admiral-edu/dispatch-typed.rkt
@@ -26,11 +26,7 @@
   (match path
     [(cons "assignments" url)
      (define page-result (assignments:load session url post))
-     ;; FIXME: this cond should be unnecessary, result should just be list of xexprs
-     (cond [(response? page-result) page-result]
-           [else (plain-page
-                  "Assignments"
-                  page-result)])]
+     page-result]
     [(list "send-test-email")
      (cond [(send-email (ct-session-uid session)
                         "Test Email sent by Captain Teach"


### PR DESCRIPTION
The `assignments:load` function return type is `Response`, so no need to call the `response?` predicate on the `page-result` since it already has that type.

This change is related to the Typed Racket pull request https://github.com/racket/typed-racket/pull/882, which fixes an unsoundness in opaque-type predicates. This change allows this code to typecheck after the unsoundness is fixed.

However, if `response?` never returns never changes its result for the same argument value, then this PR makes it simpler, changes no behavior, and lets it typecheck in both versions of typed-racket.